### PR TITLE
Make codemeta example JSON valid

### DIFF
--- a/example-codemeta.json
+++ b/example-codemeta.json
@@ -32,6 +32,6 @@
             "@id": "http://orcid.org/0000-0003-0077-4738",
             "@type": "Person",
             "email": "jones@nceas.ucsb.edu",
-            "name": "Matt Jones",
+            "name": "Matt Jones"
         }
 }


### PR DESCRIPTION
Very small issue - example-codemeta.json wasn't actually valid json because of the comma on L35. Running the example JSON through the [JSON-LD playground](http://json-ld.org/playground/) or any JSON validator wouldn't work.

@mbjones 