### PR TITLE
Add the Software Entities Model

### DIFF
--- a/crosswalk.csv
+++ b/crosswalk.csv
@@ -1,36 +1,36 @@
-Concept,CodeMeta Field,Zenodo,Figshare,code.jsonld,Software Discovery Index,Software Ontology,DataCite,Dublin Core
-SoftwareTitle,title,title,Title,name,Software title,,Title,title
-SoftwareIdentifier,identifier,id,?,citation,Persistent identifier,,Identifier,identifier
-SoftwareAuthor,author,creators,Authors(s),author,Author names and affiliations,,Creator,creator
-AuthorName, name,name,Name,name,-,,creatorName,-
-AuthorId,id,-,id(internal id/ORCID),id(ORCID),-,,nameIdentifier,-
-AuthorEmail,email,-,-,email,-,,-,-
-AuthorAffiliation,affiliation,affiliation,-,-,-,,affiliation,-
-UploadedBy,UploadedBy,?,-,-,-,,-,-
-ControlledTerm,ControlledTerm,communities,category,,-,,-,-
-ObjectType,ObjectType,upload_type,file_type,type,-,,ResourceType,type
-Tags,Tags,keywords,tags,keywords,-,,Subject,subject
-Description,Description,description/notes,Description,description,Human-readable synopsis,,Description,description
-RelatedLink,RelatedLink,related_identifiers,links,codeRepository,-,,RelatedIdentifier,relation
-CodeRepositoryLink,CodeRepository,-,-,codeRepository,Links to code repository,,-,-
-ReadmeLink,Readme,-,-,-,-,,RelatedIdentifier(relationType = isDocumentedBy),-
-BuildLink,BuildInstructions,-,-,-,-,,-,-
-CILink,ContIntegration,-,-,-,-,,-,-
-IssueLink,IssueTracker,-,-,-,-,,-,-
-AccessList,AccessList,access_right(public/embargo/private),access(private/public),-,-,,-,-
-License,License,license,License,license,Software license,,Rights,license
-datePublished,datePublished,publication_date,date_retrieved,-,-,,PublicationYear,date
-dateCreated,dateCreated,-,-,dateCreated,-,,Date(dateType = Created),created
-dateModified,dateModified,-,-,-,-,,Date(dateType = Updated),modified
-EmbargoDate,EmbargoDate,embargo_date,-,-,-,,Date(dateType = Available),available
-Inputs,Inputs,-,-,-,Formats for data inputs and outputs,,-,-
-Outputs,Outputs,-,-,-,Formats for data inputs and outputs,,-,-
-Function,Function,-,-,-,Terms to describe software objectives or functions,,-,-
-Dependency,Dependency,-,-,-,"Platform, environment, and dependencies",,-,requires
-TestCoverage,TestCoverage,-,-,-,-,,-,-
-DocsCoverage,DocsCoverage,-,-,-,-,,-,-
-IsAutomated,IsAutomatedBuild,-,-,-,-,,-,-
-Package,Package,filename,-,-,-,,-,-
-ZippedCodeLink,ZippedCode,-,file,-,-,,-,-
-Version,version,-,-,-,Software version,,Version,-
-GrantsAndPubsLink,-,-,-,-,Associated grants and publications,,-,-
+Concept,CodeMeta Field,Zenodo,Figshare,code.jsonld,Software Discovery Index,Software Ontology,DataCite,Software Entities Model (DataCite),Dublin Core
+SoftwareTitle,title,title,Title,name,Software title,,Title,Title,title
+SoftwareIdentifier,identifier,id,?,citation,Persistent identifier,,Identifier,Identifier,identifier
+SoftwareAuthor,author,creators,Authors(s),author,Author names and affiliations,,Creator,Creator,creator
+AuthorName, name,name,Name,name,-,,creatorName,,-
+AuthorId,id,-,id(internal id/ORCID),id(ORCID),-,,nameIdentifier,,-
+AuthorEmail,email,-,-,email,-,,-,,-
+AuthorAffiliation,affiliation,affiliation,-,-,-,,affiliation,,-
+UploadedBy,UploadedBy,?,-,-,-,,-,,-
+ControlledTerm,ControlledTerm,communities,category,,-,,-,,-
+ObjectType,ObjectType,upload_type,file_type,type,-,,ResourceType,ResourceType,type
+Tags,Tags,keywords,tags,keywords,-,,Subject,Subject,subject
+Description,Description,description/notes,Description,description,Human-readable synopsis,,Description,Description,description
+RelatedLink,RelatedLink,related_identifiers,links,codeRepository,-,,RelatedIdentifier,,relation
+CodeRepositoryLink,CodeRepository,-,-,codeRepository,Links to code repository,,-,,-
+ReadmeLink,Readme,-,-,-,-,,RelatedIdentifier(relationType = isDocumentedBy),,-
+BuildLink,BuildInstructions,-,-,-,-,,-,,-
+CILink,ContIntegration,-,-,-,-,,-,,-
+IssueLink,IssueTracker,-,-,-,-,,-,,-
+AccessList,AccessList,access_right(public/embargo/private),access(private/public),-,-,,-,,-
+License,License,license,License,license,Software license,,Rights,,license
+datePublished,datePublished,publication_date,date_retrieved,-,-,,PublicationYear,PublicationYear,date
+dateCreated,dateCreated,-,-,dateCreated,-,,Date(dateType = Created),,created
+dateModified,dateModified,-,-,-,-,,Date(dateType = Updated),Date (dateType = Issued),modified
+EmbargoDate,EmbargoDate,embargo_date,-,-,-,,Date(dateType = Available),Date(dateType = Available),available
+Inputs,Inputs,-,-,-,Formats for data inputs and outputs,,-,,-
+Outputs,Outputs,-,-,-,Formats for data inputs and outputs,,-,,-
+Function,Function,-,-,-,Terms to describe software objectives or functions,,-,,-
+Dependency,Dependency,-,-,-,"Platform, environment, and dependencies",,-,,requires
+TestCoverage,TestCoverage,-,-,-,-,,-,,-
+DocsCoverage,DocsCoverage,-,-,-,-,,-,,-
+IsAutomated,IsAutomatedBuild,-,-,-,-,,-,,-
+Package,Package,filename,-,-,-,,-,,-
+ZippedCodeLink,ZippedCode,-,file,-,-,,-,,-
+Version,version,-,-,-,Software version,,Version,Version,-
+GrantsAndPubsLink,-,-,-,-,Associated grants and publications,,-,,-


### PR DESCRIPTION
From here:
http://rrr.cs.st-andrews.ac.uk/wp-content/uploads/2015/10/guidelines-software-identification.pdf

This is a DataCite-based schema to represent software. It's slightly different than the existing column for Datacite which is why I added it.

Note that this is a partial map as some of the concepts don't appear to be present in CodeMeta.