### PR TITLE
Add test for Agent example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 bundler_args: --without debug
-script: "bundle exec ruby minitest/test_example_codemeta.rb"
+script: "bundle exec rake test"
 env:
   - CI=true
 rvm:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+gem 'rake'
 gem 'minitest'
+
 gem 'json-ld'

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,7 @@
+require 'rake/testtask'
+
+Rake::TestTask.new do |t|
+   t.pattern = "minitest/test_*.rb"
+   t.verbose = false
+   t.warning = false
+end

--- a/example-codemeta-agent.json
+++ b/example-codemeta-agent.json
@@ -12,9 +12,8 @@
                 "isRightsHolder": true,
                 "hasRole": [{
                     "namespace": "http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#CI_RoleCode",
-                    ["roleCode": "originator",
-                        "roleCode": "resourceProvider"
-                    ]
+                  "roleCode": [ "originator",
+                                "resourceProvider" ]
                 }]
             }, {
                 "@id": "http://orcid.org/0000-0002-3957-2474",
@@ -56,4 +55,5 @@
                     "email": "jones@nceas.ucsb.edu",
                     "name": "Matt Jones"
                 }
-            }
+            }]
+}

--- a/minitest/test_example_codemeta.rb
+++ b/minitest/test_example_codemeta.rb
@@ -1,7 +1,5 @@
-#!/usr/bin/env ruby
-require 'minitest/autorun'
-
 require 'json/ld'
+require 'minitest/autorun'
 
 describe 'example-codemeta.json' do
   before do
@@ -20,4 +18,3 @@ describe 'example-codemeta.json' do
     refute emails.empty?
   end
 end
-

--- a/minitest/test_example_codemeta_agent.rb
+++ b/minitest/test_example_codemeta_agent.rb
@@ -1,0 +1,13 @@
+require 'minitest/autorun'
+require 'json/ld'
+
+describe 'example-codemeta-agent.json' do
+  before do
+    @input = JSON.parse(File.read('example-codemeta-agent.json'))
+    @graph = JSON::LD::API.toRdf(@input)
+  end
+  
+  it 'parses to a non-empty graph' do
+    refute @graph.empty?
+  end
+end


### PR DESCRIPTION
Adds an initial test for the agent example file. Note that this test currently fails, as the file is not valid JSON.

Moves the test script into a Rake task to handle multiple minitest files.