### PR TITLE
link to crosswalk.csv rather than codemeta-crosswalk.md (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ CodeMeta is a community project with many contributors spanning research, educat
 ## How you can help
 Join us!  We welcome help formalizing a schema and creating mappings between existing software metadata schemas and the proposed schema. And writing documentation. And evangelizing. And other stuff, however you might be able to contribute.
 
-* Send us a pull request if you have any updates to our [schema](https://github.com/codemeta/codemeta/blob/master/codemeta.jsonld) or [mappings](https://github.com/codemeta/codemeta/blob/master/codemeta-crosswalk.md)!
+* Send us a pull request if you have any updates to our [schema](https://github.com/codemeta/codemeta/blob/master/codemeta.jsonld) or [mappings](https://github.com/codemeta/codemeta/blob/master/crosswalk.csv)!
 * Take a look at the [issue tracker](https://github.com/codemeta/codemeta/issues)
 * Join the discussion!
     - [Join the CodeMeta chat gitter.im](https://gitter.im/codemeta/codemeta) (May not always be active, best to ping us directly in the GitHub issues if you don't get a response).


### PR DESCRIPTION
When you click "mappings" you get a 404 at https://github.com/codemeta/codemeta/blob/master/codemeta-crosswalk.md 

By the way, I got here because I'm thinking about describing software projects over at https://github.com/IQSS/open-source-at-harvard/issues/3 and feedback there is quite welcome!