### PR TITLE
close "You can cite..." sentence logically

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ CodeMeta
 [![Build Status](https://travis-ci.org/codemeta/codemeta.svg?branch=master)](https://travis-ci.org/codemeta/codemeta)
 [![DOI](https://img.shields.io/badge/doi%3A-10.5063%2FSCHEMA%2FCODEMETA--2.0-blue.svg)](https://doi.org/10.5063/schema/codemeta-2.0)
 
-
-> *Matthew B. Jones, Carl Boettiger, Abby Cabunoc Mayes, Arfon Smith, Peter Slaughter, Kyle Niemeyer, Yolanda Gil, Martin Fenner, Krzysztof Nowak, Mark Hahnel, Luke Coy, Alice Allen, Mercè Crosas, Ashley Sands, Neil Chue Hong, Patricia Cruse, Dan Katz, Carole Goble.* 2017. __CodeMeta: an exchange schema for software metadata. Version 2.0.__ KNB Data Repository. [doi:10.5063/schema/codemeta-2.0](https://doi.org/10.5063/schema/codemeta-2.0)
-
 [CodeMeta](https://codemeta.github.io) [contributors](CONTRIBUTORS.MD) are creating a minimal metadata schema for science software and code, in JSON and XML. The goal of CodeMeta is to create a concept vocabulary that can be used to standardize the exchange of software metadata across repositories and organizations. CodeMeta started by comparing the software metadata used across multiple repositories, which resulted in the [CodeMeta Metadata Crosswalk](https://github.com/codemeta/codemeta/blob/master/crosswalk.csv).  That crosswalk was then used to generate a set of software metadata concepts, which were arranged into a JSON-LD context for serialization.
 
 See <https://codemeta.github.io> for a visualization of the [crosswalk table](https://codemeta.github.io/crosswalk) and guides for [users](https://codemeta.github.io/user-guide/) and [developers](https://codemeta.github.io/developer-guide/).
@@ -22,6 +19,7 @@ The schema for released versions of CodeMeta are:
 ## Contributors
 CodeMeta is a community project with many contributors spanning research, education, and engineering domains.    - See our [list of Contributors](CONTRIBUTORS.MD). You can cite the CodeMeta schema and project as:
 
+> *Matthew B. Jones, Carl Boettiger, Abby Cabunoc Mayes, Arfon Smith, Peter Slaughter, Kyle Niemeyer, Yolanda Gil, Martin Fenner, Krzysztof Nowak, Mark Hahnel, Luke Coy, Alice Allen, Mercè Crosas, Ashley Sands, Neil Chue Hong, Patricia Cruse, Dan Katz, Carole Goble.* 2017. __CodeMeta: an exchange schema for software metadata. Version 2.0.__ KNB Data Repository. [doi:10.5063/schema/codemeta-2.0](https://doi.org/10.5063/schema/codemeta-2.0)
 
 ## How you can help
 Join us!  We welcome help formalizing a schema and creating mappings between existing software metadata schemas and the proposed schema. And writing documentation. And evangelizing. And other stuff, however you might be able to contribute.


### PR DESCRIPTION
Hello!

I noticed that `...cite the CodeMeta schema and project as:` trails off into the next heading. Maybe the quote block got shifted upwards before it was initially committed? Since I [found no commit to revert this disconnect](https://github.com/codemeta/codemeta/blame/fc4310326054b6307b48b24176569ea175fcaad1/README.m), here is a simple fix suggestion that seems logical to me. In case something else should be done to close the sentence, please let me know.

Cheers :-)