### PR TITLE
Better example of funder and funding types

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -153,7 +153,11 @@
   "contIntegration": "https://travis-ci.org/codemeta/codemeta",
   "developmentStatus": "active",
   "downloadUrl": "https://github.com/codemeta/codemeta/archive/2.0.zip",
-  "funder": "National Science Foundation",
+  "funder": { 
+          "@id": "https://doi.org/10.13039/100000001",
+          "@type": "Organization",
+          "name": "National Science Foundation"
+  },
   "funding":"1549758; Codemeta: A Rosetta Stone for Metadata in Scientific Software",
   "keywords": [
     "metadata",

--- a/codemeta.json
+++ b/codemeta.json
@@ -153,7 +153,8 @@
   "contIntegration": "https://travis-ci.org/codemeta/codemeta",
   "developmentStatus": "active",
   "downloadUrl": "https://github.com/codemeta/codemeta/archive/2.0.zip",
-  "funding":"National Science Foundation Award #1549758; Codemeta: A Rosetta Stone for Metadata in Scientific Software",
+  "funder": "National Science Foundation",
+  "funding":"1549758; Codemeta: A Rosetta Stone for Metadata in Scientific Software",
   "keywords": [
     "metadata",
     "software"


### PR DESCRIPTION
Add funder field to example codemeta file and make it clearer that funding is for specific grant number and title information.  I'm not sure how we'd handle multiple funders and grant numbers - Ideally it would be better to have funding (grant info) be a subset of funder (like DataCite).