### PR TITLE
Java/Maven: Add SCM key to codeRepository

### DIFF
--- a/crosswalks/Java (Maven).csv
+++ b/crosswalks/Java (Maven).csv
@@ -1,5 +1,5 @@
 Property,Java (Maven)
-codeRepository,repositories
+codeRepository,scm / repositories
 programmingLanguage,
 runtimePlatform,
 targetProduct,


### PR DESCRIPTION
In Maven metadata, 'repositories' is used to fetch binary dependencies.
'scm' is closer to the meaning of codeRepository.

https://maven.apache.org/pom.html#SCM
https://maven.apache.org/pom.html#Repositories