### PR TITLE
R Package Description: Proposed changes

### DIFF
--- a/crosswalks/R Package Description.csv
+++ b/crosswalks/R Package Description.csv
@@ -15,7 +15,7 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,"Depends, SystemRequirements"
-softwareVersion,
+softwareVersion,Version
 storageRequirements,
 supportingData,
 author,[aut] in Author
@@ -43,8 +43,8 @@ isPartOf,
 hasPart,
 position,
 description,Description
-identifier,Package
-name,Title
+identifier,
+name,Package
 sameAs,
 url,URL
 relatedLink,


### PR DESCRIPTION
In context of the R Package DESCRIPTION file:
* The "Package" field better aligns the "name" property of codemeta (schema:Thing) than the "Title" field.
* The "Version" field aligns well with the "softwareVersion" property of codemeta.
* The "identifier" property of codemeta (schema:Thing) is not well represented by the "Package" field.