### PR TITLE
Update R Package Description.csv

### DIFF
--- a/crosswalks/R Package Description.csv
+++ b/crosswalks/R Package Description.csv
@@ -15,7 +15,7 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,"Depends, SystemRequirements"
-softwareVersion,
+softwareVersion,Version
 storageRequirements,
 supportingData,
 author,[aut] in Author
@@ -37,7 +37,7 @@ producer,
 provider,
 publisher,
 sponsor,
-version,
+version,Version
 isAccessibleForFree,
 isPartOf,
 hasPart,


### PR DESCRIPTION
The "Version" field of the R Package DESCRIPTION aligns with both the "softwareVersion" and "version" concepts of CodeMeta and inherited from "SoftwareApplication" and "CreativeWork", respectively. Generally, "softwareVersion" is preferred over "version" as the former is inherited from the more specific "SoftwareApplication" type as opposed to the more general "CreativeWork".

NOTE: "softwareVersion" is typed text only, whereas "version" is typed to be either numeric or text. Also, the "softwareVersion" concept seems to be less frequently used than "version".