### PR TITLE
Defining property "hasSourceCode" to link SoftwareApplication and SourceCode

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -75,6 +75,7 @@
       "readme": { "@id":"codemeta:readme", "@type": "@id" },
       "issueTracker": { "@id":"codemeta:issueTracker", "@type": "@id" },
       "referencePublication": { "@id": "codemeta:referencePublication", "@type": "@id"},
-      "maintainer": { "@id": "codemeta:maintainer" }
+      "maintainer": { "@id": "codemeta:maintainer" },
+      "hasSourceCode": { "@id": "schema:SoftwareSourceCode", "@type": "@id"},
   }
 }

--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -63,7 +63,6 @@
       "targetProduct": { "@id": "schema:targetProduct"},
       "url": { "@id": "schema:url", "@type": "@id"},
       "version": { "@id": "schema:version"},
-        
       "author": { "@id": "schema:author", "@container": "@list" },
       
       "softwareSuggestions": { "@id": "codemeta:softwareSuggestions", "@type": "@id"},
@@ -76,6 +75,6 @@
       "issueTracker": { "@id":"codemeta:issueTracker", "@type": "@id" },
       "referencePublication": { "@id": "codemeta:referencePublication", "@type": "@id"},
       "maintainer": { "@id": "codemeta:maintainer" },
-      "hasSourceCode": { "@id": "schema:SoftwareSourceCode", "@type": "@id"},
+      "hasSourceCode": { "@id": "codemeta:hasSourceCode", "@type": "@id"}
   }
 }

--- a/examples/codemeta-software.json
+++ b/examples/codemeta-software.json
@@ -1,4 +1,7 @@
 {
+"@id":"https://w3id.org/okn/i/mint/TOPOFLOW",
+"@type": "http://schema.org/SoftwareApplication",
+"http://schema.org/name": "Topoflow Hydrology model",
 "http://schema.org/author": {
   "@id": "https://w3id.org/okn/i/mint/peckham_scott", 
   "@type": "http://schema.org/Person",

--- a/examples/codemeta-software.json
+++ b/examples/codemeta-software.json
@@ -1,0 +1,24 @@
+{
+"http://schema.org/author": {
+  "@id": "https://w3id.org/okn/i/mint/peckham_scott", 
+  "@type": "http://schema.org/Person",
+  "http://schema.org/name": "Scott Peckham"}, 
+"http://schema.org/citation": "Peckham; S. D. 'Geomorphometry and spatial hydrologic modelling.' Developments in Soil Science 33 (2009): 579-602.", 
+"http://schema.org/contributor": {
+  "@id": "https://w3id.org/okn/i/mint/bolton_bob",
+  "@type": "http://schema.org/Person",
+  "http://schema.org/name": "Bob Bolton"}, 
+"http://schema.org/dateCreated": {
+  "@type": "http://schema.org/Date", 
+  "@value": "2002"}, 
+"http://schema.org/description": "Topoflow is a powerful spatially-distributed hydrologic model for various physical processes in a watershed, with the goal of accurately predicting how various hydrologic variables will evolve in time in response to climatic forcings", 
+"http://schema.org/downloadUrl": "https://csdms.colorado.edu/pub/models/doi-source-code/topoflow-10.1594.IEDA.100174-3.1.0.tar.gz", "http://schema.org/keywords": "snowmelt;precipitation;evapotranspiration;infiltration;channel/overland flow;shallow subsurface flow;flow diversions", 
+"https://codemeta.github.io/terms/referencePublication": [{"@id": "Peckham; S. D. 'Geomorphometry and spatial hydrologic modelling.' Developments in Soil Science 33 (2009): 579-602."}],   
+"https://codemeta.github.io/terms/hasSourceCode": {
+  "@id":"https://w3id.org/okn/i/mint/topoflow_source",
+  "http://schema.org/name": "Topoflow source code",
+  "https://codemeta.github.io/terms/codeRepository":"https://github.com/peckhams/topoflow",
+  "@type": "http://schema.org/SoftwareSourceCode"
+}
+}
+

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -67,11 +67,4 @@ codemeta:SoftwareSourceCode,funding,Text,Funding source (e.g. specific grant)
 codemeta:SoftwareSourceCode,issueTracker,URL,link to software bug reporting or issue tracking system
 codemeta:SoftwareSourceCode,referencePublication,ScholarlyArticle,An academic publication related to the software.
 codemeta:SoftwareSourceCode,readme,URL,link to software Readme file
-,,,
-,,,
-,,,
-,,,
-,,,
-,,,
-,,,
-,,,
+codemeta:SoftwareApplication,hasSourceCode,SoftwareSourceCode,Link that states where the software code is for a given software. This property is the inverse of schema:targetProduct. For example a software registry may indicate that one of its software entries hasSourceCode in a GitHub repository.


### PR DESCRIPTION
As we discussed in #198 (and the discussions in the Scientific Software Registry Collaboration Workshop), a link between SoftwareApplication and SoftwareSourceCode is needed for several reasons:
1) Potential adopters from software registries would like to use Codemeta, and their starting point is a software entry (SoftwareApplication) rather than a source code. 
2) Right now codemeta mixes in the spec properties from SoftwareSourceCode and SoftwareApplication. I have seen potential adopters confused on the right use of these properties. Having this link made explicit helps separating SoftwareApplication from SoftwareSourceCode.

In this pull request I have:

- Extended the properties_description.csv with a definition of the relationship proposed.
- Modified codemeta.jsonld with the appropriate domain/range for the property.
- Added an example (in examples/codemeta-software.json) on how to use the property using a SoftwareApplication and Codemeta terms. The example has been validated with https://json-ld.org/playground/

Note: I haven't added an extra line to each code meta mappings (it's the inverse of targetProduct), but will be happy to do so. 