### PR TITLE
removed duplicate key 'version'

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -163,7 +163,6 @@
     "metadata",
     "software"
   ],
-  "version":"2.0",
   "dateCreated":"2017-06-05",
   "datePublished":"2017-06-05",
   "programmingLanguage": "JSON-LD"


### PR DESCRIPTION
looks like the rename from https://github.com/codemeta/codemeta/pull/201/ accidentally created a duplicate. The other ``version`` is at line 10:

https://github.com/codemeta/codemeta/blob/18b248d9cf492d078ef6d2dde115e1aa137bbcdb/codemeta.json#L10