### PR TITLE
Disallow DateTime for dateCreated and dateModified

### DIFF
--- a/crosswalk.csv
+++ b/crosswalk.csv
@@ -23,8 +23,8 @@ schema:CreativeWork,citation,CreativeWork  or URL,"A citation or reference to an
 schema:CreativeWork,contributor,Organization  or Person,A secondary contributor to the CreativeWork or Event.,,contributor,,,,,,,,[ctb] in Author,,,,,,contributors,,,,,developer,P767,
 schema:CreativeWork,copyrightHolder,Organization  or Person,The party holding the legal copyright to the CreativeWork.,agents [role=copyrightHolder],,,,,,,,,,,,,,,,,,,,,,
 schema:CreativeWork,copyrightYear,Number,The year during which the claimed copyright for the CreativeWork was first asserted.,,,,,,,,,,,,,,,,,,,,,,,
-schema:CreativeWork,dateCreated,Date  or DateTime,The date on which the CreativeWork was created or the item was added to a DataFeed.,dateCreated,date,,,created_at,,,,created,,Date,,,,,,,,,,,P571,
-schema:CreativeWork,dateModified,Date  or DateTime,The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.,dateModified,date,,,updated_at,,,,,,,,,last-updated,,,,,,,,P5017,
+schema:CreativeWork,dateCreated,Date,The date on which the CreativeWork was created or the item was added to a DataFeed.,dateCreated,date,,,created_at,,,,created,,Date,,,,,,,,,,,P571,
+schema:CreativeWork,dateModified,Date,The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.,dateModified,date,,,updated_at,,,,,,,,,last-updated,,,,,,,,P5017,
 schema:CreativeWork,datePublished,Date,Date of first broadcast/publication.,datePublished,publicationYear,,date_published,,date_retrieved,,,date,Date,,,,,,,,Date,,,,P577,date-released
 schema:CreativeWork,editor,Person,Specifies the Person who edited the CreativeWork.,,,,,,,,,,,,,,,,,,,,,,P98,
 schema:CreativeWork,encoding,MediaObject,A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes encodings.,,,,,,,,,,,,,,,,,,,,,,,

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -23,8 +23,8 @@ schema:CreativeWork,citation,CreativeWork  or URL,"A citation or reference to an
 schema:CreativeWork,contributor,Organization  or Person,A secondary contributor to the CreativeWork or Event.
 schema:CreativeWork,copyrightHolder,Organization  or Person,The party holding the legal copyright to the CreativeWork.
 schema:CreativeWork,copyrightYear,Number,The year during which the claimed copyright for the CreativeWork was first asserted.
-schema:CreativeWork,dateCreated,Date  or DateTime,The date on which the CreativeWork was created or the item was added to a DataFeed.
-schema:CreativeWork,dateModified,Date  or DateTime,The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
+schema:CreativeWork,dateCreated,Date,The date on which the CreativeWork was created or the item was added to a DataFeed.
+schema:CreativeWork,dateModified,Date,The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
 schema:CreativeWork,datePublished,Date,Date of first broadcast/publication.
 schema:CreativeWork,editor,Person,Specifies the Person who edited the CreativeWork.
 schema:CreativeWork,encoding,MediaObject,A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes encodings.


### PR DESCRIPTION
To be consistent with the declaration in codemeta.jsonld, datePublished in this same file, and https://github.com/codemeta/codemeta.github.io/commit/1a748e64fcd44506a116cff95f27f24748873557

(I didn't realize codemeta.github.io was generated from this repo)