### PR TITLE
Change context to https

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -2,7 +2,7 @@
   "@context": {
       "type": "@type",
       "id": "@id",
-      "schema":"http://schema.org/",
+      "schema":"https://schema.org/",
       "codemeta": "https://codemeta.github.io/terms/",
       "Organization": {"@id": "schema:Organization"},
       "Person": {"@id": "schema:Person"},


### PR DESCRIPTION
Schema.org is now recommending the use of https for context linking https://github.com/schemaorg/schemaorg/issues/2578#issuecomment-698759677. They have recently changed the configuration of schema.org and http:// redirection no longer works. 

Why make this change? The validation example in https://docs.ropensci.org/codemetar/articles/articles/validation-in-json-ld.html no longer works; you'll get an error 'loading remote context failed", url = "http://schema.org"'. Changing the codemeta url to a version that uses https (e.g. https://raw.githubusercontent.com/caltechlibrary/convert_codemeta/master/codemeta.jsonld) clears the error. I've run into the same issue in Python.

There will probably need to be a new release and a new DOI, since the current DOI is tied to the 2.0 release.
