### PR TITLE
Remove restriction of 'identifier' to URIs

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -36,7 +36,7 @@
       "funder": { "@id": "schema:funder"},
       "givenName": { "@id": "schema:givenName"},
       "hasPart": { "@id": "schema:hasPart" },
-      "identifier": { "@id": "schema:identifier", "@type": "@id"},
+      "identifier": { "@id": "schema:identifier" },
       "installUrl": { "@id": "schema:installUrl", "@type": "@id"},
       "isAccessibleForFree": { "@id": "schema:isAccessibleForFree"},
       "isPartOf":  { "@id": "schema:isPartOf"},


### PR DESCRIPTION
In practice, it is used to store non-URI identifiers, such as HAL IDs or (arguably ambiguous) names like here:

https://github.com/codemeta/codemeta/blob/7e51f02426f1a6d9e86edb3e99024dd0999ef97e/codemeta.json#L4