### PR TITLE
[wikidata] Replace issue tracker URL

### DIFF
--- a/crosswalks/Wikidata.csv
+++ b/crosswalks/Wikidata.csv
@@ -67,7 +67,7 @@ buildInstructions,
 developmentStatus,
 embargoEndDate,
 funding,
-issueTracker,bug tracking system
+issueTracker,P1401
 referencePublication,
 readme,
 hasSourceCode,


### PR DESCRIPTION
 issue tracker URL (P1401) https://www.wikidata.org/wiki/Property:P1401 is the wikidata property associated with issue tracking