### PR TITLE
fix: adjust maven mappings for codemeta v3

### DIFF
--- a/crosswalks/Java (Maven).csv
+++ b/crosswalks/Java (Maven).csv
@@ -1,22 +1,22 @@
 Property,Java (Maven)
-codeRepository,scm
+codeRepository,scm / url
 programmingLanguage,
 review,
 runtimePlatform,
 targetProduct,
 applicationCategory,
 applicationSubCategory,
-downloadUrl,distributionManagement
+downloadUrl,distributionManagement / downloadUrl
 fileSize,
 installUrl,
 memoryRequirements,
 operatingSystem,
 permissions,
 processorRequirements,
-releaseNotes,description
+releaseNotes,
 softwareHelp,
 softwareRequirements,dependencies
-softwareVersion,
+softwareVersion,version
 storageRequirements,
 supportingData,
 author,developers
@@ -32,7 +32,7 @@ encoding,
 fileFormat,
 funder,
 keywords,
-license,license
+license,licenses / license / url
 producer,
 provider,
 publisher,

--- a/crosswalks/Java (Maven).csv
+++ b/crosswalks/Java (Maven).csv
@@ -1,30 +1,30 @@
 Property,Java (Maven)
-codeRepository,scm / repositories
+codeRepository,scm
 programmingLanguage,
 review,
 runtimePlatform,
 targetProduct,
 applicationCategory,
 applicationSubCategory,
-downloadUrl,
+downloadUrl,distributionManagement
 fileSize,
 installUrl,
 memoryRequirements,
 operatingSystem,
 permissions,
 processorRequirements,
-releaseNotes,
+releaseNotes,description
 softwareHelp,
-softwareRequirements,prerequisites
+softwareRequirements,dependencies
 softwareVersion,
 storageRequirements,
 supportingData,
-author,
+author,developers
 citation,
-contributor,
+contributor,contributors
 copyrightHolder,
 copyrightYear,
-dateCreated,
+dateCreated,inceptionYear
 dateModified,
 datePublished,
 editor,
@@ -43,10 +43,10 @@ isPartOf,
 hasPart,
 position,
 description,description
-identifier,groupId
+identifier,groupId / artifactId
 name,name
 sameAs,
-url,
+url,url
 relatedLink,
 givenName,
 familyName,


### PR DESCRIPTION
bring Java/Maven crosswalk mapping to codemeta v3 and adjust some of the original mappings to the Maven Project Object Model

https://maven.apache.org/pom.html

- codeRepository should point at the place where the human readable uncompiled source code lives so `scm`
(https://maven.apache.org/pom.html#scm) is the right choice, not repositories (https://maven.apache.org/pom.html#repositories)
- softwareRequirements is for the source code's dependencies (https://maven.apache.org/pom.html#dependencies), not the maven pom.xml's prerequisites (https://maven.apache.org/pom.html#prerequisites) 
- one issue on dependencies is that Maven does transitive dependency management so the full set of dependencies is not resolved in this pom but would need to be programmatically generated (e.g., `mvn dependency:tree` or `mvn dependency:list`)