### PR TITLE
Fix CSV column inconsistency and roleName type

### DIFF
--- a/properties_description.csv
+++ b/properties_description.csv
@@ -58,7 +58,7 @@ schema:Person,address,PostalAddress or Text,Physical address of the item.
 schema:Review,reviewAspect,Text,This review is relevant to this part or facet of the object being review
 schema:Review,reviewBody,Text,The actual body of the review
 schema:Role,endDate,Date or Datetime,"The end date and time of the item, usually a Role. In ISO 8601 date format"
-schema:Role,roleName,Text,"A role played, performed, or filled by a person or organization. Suggested values: ""Design"" (algorithm), ""Architecture"", ""Debugging"", ""Maintenance"", ""Coding"", ""Documentation"", ""Testing"", ""Support"", ""Management""."
+schema:Role,roleName,Text or URL,"A role played, performed, or filled by a person or organization. Suggested values: ""Design"" (algorithm), ""Architecture"", ""Debugging"", ""Maintenance"", ""Coding"", ""Documentation"", ""Testing"", ""Support"", ""Management""."
 schema:Role,startDate,Date or Datetime,"The start date and time of the item, usually a Role. In ISO 8601 date format"
 codemeta:SoftwareSourceCode,softwareSuggestions,SoftwareSourceCode,"Optional dependencies, e.g. for optional features, code development, etc."
 codemeta:SoftwareSourceCode,maintainer,Person,Individual responsible for maintaining the software (usually includes an email contact address)

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -57,7 +57,7 @@ schema:Person,name,Text,"The name of an Organization, or if separate given and f
 schema:Person,address,PostalAddress or Text,Physical address of the item.
 schema:Review,reviewAspect,Text,This Review is relevant to this part or facet of the object being review
 schema:Review,reviewBody,Text,The actual body of the review
-schema:Role,endDate,Date or Datetime,The end date and time of the item, usually a Role. In ISO 8601 date format
+schema:Role,endDate,Date or Datetime,"The end date and time of the item, usually a Role. In ISO 8601 date format"
 schema:Role,roleName,Text,URL,"A role played, performed, or filled by a person or organization. Suggested values: ""Design"" (algorithm), ""Architecture"", ""Debugging"", ""Maintenance"", ""Coding"", ""Documentation"", ""Testing"", ""Support"", ""Management""."
 schema:Role,startDate,Date or Datetime,The start date and time of the item, usually a Role. In ISO 8601 date format
 codemeta:SoftwareSourceCode,softwareSuggestions,SoftwareSourceCode,"Optional dependencies , e.g. for optional features, code development, etc."

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -58,7 +58,7 @@ schema:Person,address,PostalAddress or Text,Physical address of the item.
 schema:Review,reviewAspect,Text,This Review is relevant to this part or facet of the object being review
 schema:Review,reviewBody,Text,The actual body of the review
 schema:Role,endDate,Date or Datetime,"The end date and time of the item, usually a Role. In ISO 8601 date format"
-schema:Role,roleName,Text,URL,"A role played, performed, or filled by a person or organization. Suggested values: ""Design"" (algorithm), ""Architecture"", ""Debugging"", ""Maintenance"", ""Coding"", ""Documentation"", ""Testing"", ""Support"", ""Management""."
+schema:Role,roleName,Text,"A role played, performed, or filled by a person or organization. Suggested values: ""Design"" (algorithm), ""Architecture"", ""Debugging"", ""Maintenance"", ""Coding"", ""Documentation"", ""Testing"", ""Support"", ""Management""."
 schema:Role,startDate,Date or Datetime,The start date and time of the item, usually a Role. In ISO 8601 date format
 codemeta:SoftwareSourceCode,softwareSuggestions,SoftwareSourceCode,"Optional dependencies , e.g. for optional features, code development, etc."
 codemeta:SoftwareSourceCode,maintainer,Person,Individual responsible for maintaining the software (usually includes an email contact address)

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -1,49 +1,49 @@
 Parent Type,Property,Type,Description
-schema:SoftwareSourceCode,codeRepository,URL,"Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex, institutional GitLab instance, etc.)."
-schema:SoftwareSourceCode,programmingLanguage,ComputerLanguage  or Text,The computer programming language.
+schema:SoftwareSourceCode,codeRepository,URL,"A link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex, institutional GitLab instance, etc.)."
+schema:SoftwareSourceCode,programmingLanguage,ComputerLanguage or Text,The computer programming language.
 schema:SoftwareSourceCode,review,Review,A review of the source code.
 schema:SoftwareSourceCode,runtimePlatform,Text,"Runtime platform or script interpreter dependencies (Example - Java v1, Python2.3, .Net Framework 3.0). Supersedes runtime."
 schema:SoftwareSourceCode,targetProduct,SoftwareApplication,"Target Operating System / Product to which the code applies. If applies to several versions, just the product name can be used."
-schema:SoftwareApplication,applicationCategory,Text  or URL,"Type of software application, e.g. 'Game, Multimedia'."
-schema:SoftwareApplication,applicationSubCategory,Text  or URL,"Subcategory of the application, e.g. 'Arcade Game'."
+schema:SoftwareApplication,applicationCategory,Text or URL,"Type of software application, e.g. 'Game, Multimedia'."
+schema:SoftwareApplication,applicationSubCategory,Text or URL,"Subcategory of the application, e.g. 'Arcade Game'."
 schema:SoftwareApplication,downloadUrl,URL,"If the file can be downloaded, URL to download the binary."
 schema:SoftwareApplication,fileSize,Text,"Size of the application / package (e.g. 18MB). In the absence of a unit (MB, KB etc.), KB will be assumed."
 schema:SoftwareApplication,installUrl,URL,"URL at which the app may be installed, if different from the URL of the item."
-schema:SoftwareApplication,memoryRequirements,Text  or URL,Minimum memory requirements.
+schema:SoftwareApplication,memoryRequirements,Text or URL,Minimum memory requirements.
 schema:SoftwareApplication,operatingSystem,Text,"Operating systems supported (Windows 7, OSX 10.6, Android 1.6)."
 schema:SoftwareApplication,permissions,Text,"Permission(s) required to run the app (for example, a mobile app may require full internet access or may run only on wifi)."
 schema:SoftwareApplication,processorRequirements,Text,Processor architecture required to run the application (e.g. IA64).
-schema:SoftwareApplication,releaseNotes,Text  or URL,Description of what changed in this version.
+schema:SoftwareApplication,releaseNotes,Text or URL,Description of what changed in this version.
 schema:SoftwareApplication,softwareHelp,CreativeWork,Software application help.
 schema:SoftwareApplication,softwareRequirements,SoftwareSourceCode,Required software dependencies
 schema:SoftwareApplication,softwareVersion,Text,Version of the software instance.
-schema:SoftwareApplication,storageRequirements,Text  or URL,Storage requirements (free space required).
+schema:SoftwareApplication,storageRequirements,Text or URL,Storage requirements (free space required).
 schema:SoftwareApplication,supportingData,DataFeed,Supporting data for a SoftwareApplication.
-schema:CreativeWork,author,Organization  or Person,The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
-schema:CreativeWork,citation,CreativeWork  or URL,"A citation or reference to another creative work, such as another publication, web page, scholarly article, etc."
-schema:CreativeWork,contributor,Organization  or Person,A secondary contributor to the CreativeWork or Event.
-schema:CreativeWork,copyrightHolder,Organization  or Person,The party holding the legal copyright to the CreativeWork.
+schema:CreativeWork,author,Organization or Person,The author of this content or rating. Please note that author is special in that HTML 5 provides a special mechanism for indicating authorship via the rel tag. That is equivalent to this and may be used interchangeably.
+schema:CreativeWork,citation,CreativeWork or URL,"A citation or reference to another creative work, such as another publication, web page, scholarly article, etc."
+schema:CreativeWork,contributor,Organization or Person,A secondary contributor to the CreativeWork or Event.
+schema:CreativeWork,copyrightHolder,Organization or Person,The party holding the legal copyright to the CreativeWork.
 schema:CreativeWork,copyrightYear,Number,The year during which the claimed copyright for the CreativeWork was first asserted.
 schema:CreativeWork,dateCreated,Date,The date on which the CreativeWork was created or the item was added to a DataFeed.
 schema:CreativeWork,dateModified,Date,The date on which the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed.
 schema:CreativeWork,datePublished,Date,Date of first broadcast/publication.
 schema:CreativeWork,editor,Person,Specifies the Person who edited the CreativeWork.
 schema:CreativeWork,encoding,MediaObject,A media object that encodes this CreativeWork. This property is a synonym for associatedMedia. Supersedes encodings.
-schema:CreativeWork,fileFormat,Text  or URL,"Media type, typically MIME format (see IANA site) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry."
+schema:CreativeWork,fileFormat,Text or URL,"Media type, typically MIME format (see IANA site) of the content e.g. application/zip of a SoftwareApplication binary. In cases where a CreativeWork has several media type representations, 'encoding' can be used to indicate each MediaObject alongside particular fileFormat information. Unregistered or niche file formats can be indicated instead via the most appropriate URL, e.g. defining Web page or a Wikipedia entry."
 schema:CreativeWork,funder,Organization or Person,A person or organization that supports (sponsors) something through some kind of financial contribution.
 schema:CreativeWork,keywords,Text,Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas.
-schema:CreativeWork,license,CreativeWork  or URL,"A license document that applies to this content, typically indicated by URL."
-schema:CreativeWork,producer,Organization  or Person,"The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.)."
-schema:CreativeWork,provider,Organization  or Person,"The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes carrier."
-schema:CreativeWork,publisher,Organization  or Person,The publisher of the creative work.
-schema:CreativeWork,sponsor,Organization  or Person,"A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event."
-schema:CreativeWork,version,Number  or Text,The version of the CreativeWork embodied by a specified resource.
+schema:CreativeWork,license,CreativeWork or URL,"A license document that applies to this content, typically indicated by URL."
+schema:CreativeWork,producer,Organization or Person,"The person or organization who produced the work (e.g. music album, movie, tv/radio series etc.)."
+schema:CreativeWork,provider,Organization or Person,"The service provider, service operator, or service performer; the goods producer. Another party (a seller) may offer those services or goods on behalf of the provider. A provider may also serve as the seller. Supersedes carrier."
+schema:CreativeWork,publisher,Organization or Person,The publisher of the creative work.
+schema:CreativeWork,sponsor,Organization or Person,"A person or organization that supports a thing through a pledge, promise, or financial contribution. e.g. a sponsor of a Medical Study or a corporate sponsor of an event."
+schema:CreativeWork,version,Number or Text,The version of the CreativeWork embodied by a specified resource.
 schema:CreativeWork,isAccessibleForFree,Boolean,A flag to signal that the publication is accessible for free.
 schema:CreativeWork,isPartOf,CreativeWork,Indicates a CreativeWork that this CreativeWork is (in some sense) part of. Reverse property hasPart
 schema:CreativeWork,hasPart,CreativeWork,Indicates a CreativeWork that is (in some sense) a part of this CreativeWork. Reverse property isPartOf
-schema:CreativeWork,position,Integer or Text,"The position of an item in a series or sequence of items. (While schema.org considers this a property of CreativeWork, it is also the way to indicate ordering in any list (e.g. the Authors list).  By default arrays are unordered in JSON-LD"
+schema:CreativeWork,position,Integer or Text,"The position of an item in a series or sequence of items. (While schema.org considers this a property of CreativeWork, it is also the way to indicate ordering in any list (e.g. the Authors list). By default arrays are unordered in JSON-LD"
 schema:Thing,description,Text,A description of the item.
-schema:Thing,identifier,PropertyValue  or URL,"The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See background notes for more details."
+schema:Thing,identifier,PropertyValue or URL,"The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See background notes for more details."
 schema:Thing,name,Text,"The name of the item (software, Organization)"
 schema:Thing,sameAs,URL,"URL of a reference Web page that unambiguously indicates the item's identity. E.g. the URL of the item's Wikipedia page, Wikidata entry, or official website."
 schema:Thing,url,URL,URL of the item.
@@ -55,23 +55,23 @@ schema:Person,affiliation,Organization,"An organization that this person is affi
 schema:Person,identifier,URL,"URL identifier, ideally an ORCID ID for individuals, a FundRef ID for funders"
 schema:Person,name,Text,"The name of an Organization, or if separate given and family names cannot be resolved for a Person"
 schema:Person,address,PostalAddress or Text,Physical address of the item.
-schema:Review,reviewAspect,Text,This Review is relevant to this part or facet of the object being review
+schema:Review,reviewAspect,Text,This review is relevant to this part or facet of the object being review
 schema:Review,reviewBody,Text,The actual body of the review
 schema:Role,endDate,Date or Datetime,"The end date and time of the item, usually a Role. In ISO 8601 date format"
 schema:Role,roleName,Text,"A role played, performed, or filled by a person or organization. Suggested values: ""Design"" (algorithm), ""Architecture"", ""Debugging"", ""Maintenance"", ""Coding"", ""Documentation"", ""Testing"", ""Support"", ""Management""."
-schema:Role,startDate,Date or Datetime,The start date and time of the item, usually a Role. In ISO 8601 date format
-codemeta:SoftwareSourceCode,softwareSuggestions,SoftwareSourceCode,"Optional dependencies , e.g. for optional features, code development, etc."
+schema:Role,startDate,Date or Datetime,"The start date and time of the item, usually a Role. In ISO 8601 date format"
+codemeta:SoftwareSourceCode,softwareSuggestions,SoftwareSourceCode,"Optional dependencies, e.g. for optional features, code development, etc."
 codemeta:SoftwareSourceCode,maintainer,Person,Individual responsible for maintaining the software (usually includes an email contact address)
-codemeta:SoftwareSourceCode,continuousIntegration,URL,link to continuous integration service
-codemeta:SoftwareSourceCode,buildInstructions,URL,link to installation instructions/documentation
-codemeta:SoftwareSourceCode,developmentStatus,Text,"Description of development status, e.g. Active, inactive, suspended. See repostatus.org"
+codemeta:SoftwareSourceCode,continuousIntegration,URL,A link to continuous integration service
+codemeta:SoftwareSourceCode,buildInstructions,URL,A link to installation instructions/documentation
+codemeta:SoftwareSourceCode,developmentStatus,Text,"Description of development status, e.g. active, inactive, suspended. See repostatus.org"
 codemeta:SoftwareSourceCode,embargoEndDate,Date,"Software may be embargoed from public access until a specified date (e.g. pending publication, 1 year from publication)"
 codemeta:SoftwareSourceCode,funding,Text,Funding source (e.g. specific grant)
-codemeta:SoftwareSourceCode,issueTracker,URL,link to software bug reporting or issue tracking system
+codemeta:SoftwareSourceCode,issueTracker,URL,A link to software bug reporting or issue tracking system
 codemeta:SoftwareSourceCode,referencePublication,ScholarlyArticle,An academic publication related to the software.
-codemeta:SoftwareSourceCode,readme,URL,link to software Readme file
-codemeta:SoftwareApplication,hasSourceCode,SoftwareSourceCode,Link that states where the software code is for a given software. For example a software registry may indicate that one of its software entries hasSourceCode in a GitHub repository.
-codemeta:SoftwareSourceCode,isSourceCodeOf,SoftwareApplication,Link that states where software application is built from a given source code. This is the reverse property of 'hasSourceCode'.
+codemeta:SoftwareSourceCode,readme,URL,A link to software Readme file
+codemeta:SoftwareApplication,hasSourceCode,SoftwareSourceCode,A link that states where the software code is for a given software. For example a software registry may indicate that one of its software entries hasSourceCode in a GitHub repository.
+codemeta:SoftwareSourceCode,isSourceCodeOf,SoftwareApplication,A link that states where software application is built from a given source code. This is the reverse property of 'hasSourceCode'.
 ,,,
 ,,,
 ,,,

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -73,10 +73,3 @@ codemeta:SoftwareSourceCode,readme,URL,A link to software Readme file
 codemeta:SoftwareApplication,hasSourceCode,SoftwareSourceCode,A link that states where the software code is for a given software. For example a software registry may indicate that one of its software entries hasSourceCode in a GitHub repository.
 codemeta:SoftwareSourceCode,isSourceCodeOf,SoftwareApplication,A link that states where software application is built from a given source code. This is the reverse property of 'hasSourceCode'.
 ,,,
-,,,
-,,,
-,,,
-,,,
-,,,
-,,,
-,,,

--- a/properties_description.csv
+++ b/properties_description.csv
@@ -72,4 +72,3 @@ codemeta:SoftwareSourceCode,referencePublication,ScholarlyArticle,An academic pu
 codemeta:SoftwareSourceCode,readme,URL,A link to software Readme file
 codemeta:SoftwareApplication,hasSourceCode,SoftwareSourceCode,A link that states where the software code is for a given software. For example a software registry may indicate that one of its software entries hasSourceCode in a GitHub repository.
 codemeta:SoftwareSourceCode,isSourceCodeOf,SoftwareApplication,A link that states where software application is built from a given source code. This is the reverse property of 'hasSourceCode'.
-,,,


### PR DESCRIPTION
## Fix CSV column inconsistency and roleName type
- Line 60 and 62: Add quotes around the last field (which contains a comma `,` that can confused CSV parser and thought that the rows have 5 columns instead of 4)
- Line 61: `roleName` should be `Text or URL` (currently it has Text followed by URL - `Text,URL`, which also make it 5 columns)

By fixing these column number inconsistencies, GitHub will able to display the file as a table.

## Format/description consistency
- Line 65, 66, 70, 72: Capitalizes first character in the sentence.
- Put "a" determiner for "link", make it "a link" just as "a license", "a flag", etc. as appeared in other property descriptions.
- Replace double spaces with single spaces

