### PR TITLE
Update CONTRIBUTORS.MD - make consistency

### DIFF
--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -102,3 +102,13 @@ operates according to the rules specified in the
 - [@noamross](https://github.com/noamross)
 - [@progval](https://github.com/progval)
 - [@tmorell](https://github.com/tmorrell)
+
+## Post-V3.0 contributors
+
+| Name             | Email                | Institution             | GitHub  |
+|------------------|----------------------|-------------------------| --------|
+| Arthit Suriyawongkul | | Trinity College Dublin | [@bact](https://github.com) |
+| Daniel Garijo | | Universidad Politécnica de Madrid | [@dgarijo](https://github.com/dgarijo) |
+| Val Lorentz | | Software Heritage | [@progval](https://github.com/progval) |
+| | | | [@bandrow](https://github.com/bandrow) |
+

--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -90,7 +90,7 @@ operates according to the rules specified in the
 | Satvik Vemuganti | | | [@VickyMerzOwn](https://github.com/VickyMerzOwn) |
 | Thomas Vuillaume | | Univ. Savoie Mont-Blanc, CNRS, LAPP | [@vuillaut](https://github.com/vuillaut) |
 
-## V3.0 contributors (July 3, 2023)
+## V3.0 contributors (Jul 3, 2023)
 
 - [@agbeltran](https://github.com/agbeltran)
 - [@arfon](https://github.com/arfon)

--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -1,31 +1,35 @@
 # Contributors
-In this file we collected the names of individuals who have contributed to the CodeMeta vocabulary, crosswalks and specification. We welcome pull requests from people to add to this list if we missed anybody.
+
+In this file we collected the names of individuals who have contributed to the
+CodeMeta vocabulary, crosswalks and specification. We welcome pull requests
+from people to add to this list if we missed anybody.
 
 ## Project Management Committee (PMC)
-The PMC is ensuring that the CodeMeta community is an open community that operates according to the rules specified in the [codemeta-governance repository](https://github.com/codemeta/governance).
 
-| Name             | Email                | Institution               | GitHub  |
+The PMC is ensuring that the CodeMeta community is an open community that
+operates according to the rules specified in the
+[codemeta-governance repository](https://github.com/codemeta/governance).
+
+| Name             | Email                | Institution             | GitHub  |
 |------------------|----------------------|-------------------------| --------|
-| Matthew B. Jones | jones@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [@mbjones](http://github.com/mbjones) |
-| Carl Boettiger   | | UC Berkeley | [cboettig](http://github.com/cboettig) |
-| Abby Cabunoc Mayes | | Mozilla Science Lab | [@acabunoc](http://github.com/acabunoc) |
-| Arfon Smith | | GitHub | [@arfon](http://github.com/arfon) |
+| Matthew B. Jones | jones@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [@mbjones](https://github.com/mbjones) |
+| Carl Boettiger | | UC Berkeley | [@cboettig](https://github.com/cboettig) |
+| Abby Cabunoc Mayes | | Mozilla Science Lab | [@acabunoc](https://github.com/acabunoc) |
+| Arfon Smith | | GitHub | [@arfon](https://github.com/arfon) |
 | Morane Gruenpeter | morane@softwareheritage.org | Software Heritage | [@moranegg](https://github.com/moranegg) |
 | Valentin Lorentz | vlorentz@softwareheritage.org | Software Heritage | [@progval](https://github.com/progval) |
 | Thomas Morrell | tmorrell@library.caltech.edu | Caltech Library | [@tmorell](https://github.com/tmorrell) |
-| Daniel Garijo |  |  Universidad Politécnica de Madrid | [@dgarijo](https://github.com/dgarijo)  |
-
+| Daniel Garijo | | Universidad Politécnica de Madrid | [@dgarijo](https://github.com/dgarijo) |
 
 ## V1.0 contributors (Jan 6, 2017)
 
-| Name             | Email                | Institution               | GitHub  |
+| Name             | Email                | Institution             | GitHub  |
 |------------------|----------------------|-------------------------| --------|
-| Matthew B. Jones | jones@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [mbjones](http://github.com/mbjones) |
-| Carl Boettiger   | | UC Berkeley | [cboettig](http://github.com/cboettig) |
-| Abby Cabunoc Mayes | | Mozilla Science Lab | [acabunoc](http://github.com/acabunoc) |
-| Arfon Smith | | GitHub | [arfon](http://github.com/arfon) |
-| Peter Slaughter | slaughter@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [gothub](http://github.com/gothub) |
-| Kyle Niemeyer   | | | [kyleniemeyer](http://github.com/kyleniemeyer) |
+| Matthew B. Jones | jones@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [@mbjones](https://github.com/mbjones) |
+| Carl Boettiger | | UC Berkeley | [@cboettig](https://github.com/cboettig) |
+| Abby Cabunoc Mayes | | Mozilla Science Lab | [@acabunoc](https://github.com/acabunoc) |
+| Peter Slaughter | slaughter@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [@gothub](https://github.com/gothub) |
+| Kyle Niemeyer | | | [@kyleniemeyer](https://github.com/kyleniemeyer) |
 | Yolanda Gil | | USC ISI | |
 | Martin Fenner | | DataCite | |
 | Krzysztof Nowak | | Zenodo | |
@@ -38,65 +42,63 @@ The PMC is ensuring that the CodeMeta community is an open community that operat
 | Patricia Cruse | | DataCite | |
 | Dan Katz | | NCSA | |
 | Carole Goble | | | |
-| Ted Habermann | ted.habermann@gmail.com |  | [tedhabermann](https://github.com/tedhabermann) |
+| Ted Habermann | ted.habermann@gmail.com | | [@tedhabermann](https://github.com/tedhabermann) |
 
 ## V2.0 contributors (Sep 29, 2020)
 
-As list:
-- https://github.com/gothub
-- https://github.com/cboettig
-- https://github.com/emulatingkat
-- https://github.com/kyleniemeyer
-- https://github.com/abbycabs
-- https://github.com/progval
-- https://github.com/amoeba
-- https://github.com/sdruskat
-- https://github.com/tmorrell
-- https://github.com/arfon
-- https://github.com/zoidy
-- https://github.com/jspaaks
-- https://github.com/hmenager
-- https://github.com/mkuzak
-- https://github.com/larsgw
-- https://github.com/dr-shorthair
-- https://github.com/encima
-- https://github.com/tedhabermann
-- https://github.com/danielskatz
-- https://github.com/katrinleinweber
-- https://github.com/npch
-- https://github.com/pdurbin
-- https://github.com/atla5
-- https://github.com/moranegg
-- https://github.com/nuest
-- https://github.com/lukecoy
-- https://github.com/qb-x
-- https://github.com/hubgit
+- [@gothub](https://github.com/gothub)
+- [@cboettig](https://github.com/cboettig)
+- [@emulatingkat](https://github.com/emulatingkat)
+- [@kyleniemeyer](https://github.com/kyleniemeyer)
+- [@abbycabs](https://github.com/abbycabs)
+- [@progval](https://github.com/progval)
+- [@amoeba](https://github.com/amoeba)
+- [@sdruskat](https://github.com/sdruskat)
+- [@tmorrell](https://github.com/tmorrell)
+- [@arfon](https://github.com/arfon)
+- [@zoidy](https://github.com/zoidy)
+- [@jspaaks](https://github.com/jspaaks)
+- [@hmenager](https://github.com/hmenager)
+- [@mkuzak](https://github.com/mkuzak)
+- [@larsgw](https://github.com/larsgw)
+- [@dr-shorthair](https://github.com/dr-shorthair)
+- [@encima](https://github.com/encima)
+- [@tedhabermann](https://github.com/tedhabermann)
+- [@danielskatz](https://github.com/danielskatz)
+- [@katrinleinweber](https://github.com/katrinleinweber)
+- [@npch](https://github.com/npch)
+- [@pdurbin](https://github.com/pdurbin)
+- [@atla5](https://github.com/atla5)
+- [@moranegg](https://github.com/moranegg)
+- [@nuest](https://github.com/nuest)
+- [@lukecoy](https://github.com/lukecoy)
+- [@qb-x](https://github.com/qb-x)
+- [@hubgit](https://github.com/hubgit)
 
+## V2.1 contributors (Apr 24, 2023)
 
-## V2.1 contributors (24 Apr, 2023)
-
-| Name             | Email                | Institution               | GitHub  |
+| Name             | Email                | Institution             | GitHub  |
 |------------------|----------------------|-------------------------| --------|
-| Matthew B. Jones | jones@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [mbjones](http://github.com/mbjones) |
-| Carl Boettiger   | | UC Berkeley | [cboettig](http://github.com/cboettig) |
+| Matthew B. Jones | jones@nceas.ucsb.edu | NCEAS, UC Santa Barbara | [@mbjones](https://github.com/mbjones) |
+| Carl Boettiger | | UC Berkeley | [@cboettig](https://github.com/cboettig) |
 | Morane Gruenpeter | morane@softwareheritage.org | Software Heritage | [@moranegg](https://github.com/moranegg) |
 | Valentin Lorentz | vlorentz@softwareheritage.org | Software Heritage | [@progval](https://github.com/progval) |
 | Thomas Morrell | tmorrell@library.caltech.edu | Caltech Library | [@tmorell](https://github.com/tmorrell) |
-| Stephan Druskat |  | German Aerospace Center (DLR)  | [@sdruskat](https://github.com/sdruskat)  |
-| Colin Smith | | Enivronmental Data Initiative | [@clnsmt](https://github.com/clnsmth)  |
-| Jurriaan H. Spaaks |  | Netherlands eScience Center  | [@jspaaks](https://github.com/jspaaks) |
-| Satvik Vemuganti | | | [@VickyMerzOwn](https://github.com/VickyMerzOwn)|
+| Stephan Druskat | | German Aerospace Center (DLR) | [@sdruskat](https://github.com/sdruskat) |
+| Colin Smith | | Enivronmental Data Initiative | [@clnsmt](https://github.com/clnsmth) |
+| Jurriaan H. Spaaks | | Netherlands eScience Center | [@jspaaks](https://github.com/jspaaks) |
+| Satvik Vemuganti | | | [@VickyMerzOwn](https://github.com/VickyMerzOwn) |
 | Thomas Vuillaume | | Univ. Savoie Mont-Blanc, CNRS, LAPP | [@vuillaut](https://github.com/vuillaut) |
 
-## V3.0 contributors (3 July, 2023)
+## V3.0 contributors (July 3, 2023)
+
 - [@agbeltran](https://github.com/agbeltran)
-- [@arfon]([@arfon](http://github.com/arfon))
-- [@cboettig](http://github.com/cboettig)
+- [@arfon](https://github.com/arfon)
+- [@cboettig](https://github.com/cboettig)
 - [@dgarijo](https://github.com/dgarijo)
-- [@mbjones](http://github.com/mbjones) 
+- [@mbjones](https://github.com/mbjones)
 - [@mfenner](https://github.com/mfenner)
 - [@moranegg](https://github.com/moranegg)
 - [@noamross](https://github.com/noamross)
-- [@progval](https://github.com/progval) 
-- [@tmorell](https://github.com/tmorrell) 
-
+- [@progval](https://github.com/progval)
+- [@tmorell](https://github.com/tmorrell)


### PR DESCRIPTION
- Add @ to those GitHub usernames without
- Add GitHub username text label to bare links (in V2.0 list)
- Replace `http://` links with `https://`
- Fix broken links
- Remove extra spaces
- Use same date format across the document
- Add Post-V3.0 contributors for crosswalks contributors
  - dgarijo for #327
  - progval and bandrow for #331
  - bact for #344