### PR TITLE
VIVO crosswalk

### DIFF
--- a/crosswalks/VIVO.csv
+++ b/crosswalks/VIVO.csv
@@ -1,4 +1,4 @@
-Property,VIVO (ontology URI - https://github.com/vivo-ontologies/vivo-ontology/blob/master/vivo.owl, Software main class URI - http://purl.obolibrary.org/obo/ERO_0000071)
+Property,VIVO (ontology URI - https://github.com/vivo-ontologies/vivo-ontology/blob/master/vivo.owl; Software main class URI - http://purl.obolibrary.org/obo/ERO_0000071)
 codeRepository,
 programmingLanguage,
 review,
@@ -16,44 +16,44 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,
-softwareVersion,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072, range URI - http://www.w3.org/2001/XMLSchema#string)
+softwareVersion,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072; range URI - http://www.w3.org/2001/XMLSchema#string)
 storageRequirements,
 supportingData,
-author,relatedBy.relates (property URI - http://vivoweb.org/ontology/core#relatedBy, http://vivoweb.org/ontology/core#relates, range URI - http://vivoweb.org/ontology/core#Authorship, http://xmlns.com/foaf/0.1/Agent)
+author,relatedBy.relates (property URI - http://vivoweb.org/ontology/core#relatedBy; http://vivoweb.org/ontology/core#relates; range URI - http://vivoweb.org/ontology/core#Authorship; http://xmlns.com/foaf/0.1/Agent)
 citation,
 contributor,
 copyrightHolder,
 copyrightYear,
 dateCreated,
 dateModified,
-datePublished,date/time value (property URI - http://vivoweb.org/ontology/core#dateTimeValue, range URI - http://vivoweb.org/ontology/core#DateTimeValue)
+datePublished,date/time value (property URI - http://vivoweb.org/ontology/core#dateTimeValue; range URI - http://vivoweb.org/ontology/core#DateTimeValue)
 editor,
 encoding,
 fileFormat,
-funder,informationResourceSupportedBy.assignedBy (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy, http://vivoweb.org/ontology/core#assignedBy, range URI - http://vivoweb.org/ontology/core#Grant, http://xmlns.com/foaf/0.1/Organization)
-keywords,freetextKeywords (property URI - http://vivoweb.org/ontology/core#freetextKeyword, range URI - http://www.w3.org/2001/XMLSchema#string)
+funder,informationResourceSupportedBy.assignedBy (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy; http://vivoweb.org/ontology/core#assignedBy; range URI - http://vivoweb.org/ontology/core#Grant; http://xmlns.com/foaf/0.1/Organization)
+keywords,freetextKeywords (property URI - http://vivoweb.org/ontology/core#freetextKeyword; range URI - http://www.w3.org/2001/XMLSchema#string)
 license,
 producer,
 provider,
 publisher,
 sponsor,
-version,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072, range URI - http://www.w3.org/2001/XMLSchema#string)
+version,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072; range URI - http://www.w3.org/2001/XMLSchema#string)
 isAccessibleForFree,
-isPartOf,partOf (property URI - http://purl.obolibrary.org/obo/BFO_0000050, range URI - http://purl.obolibrary.org/obo/ERO_0000071)
-hasPart,hasPart (property URI - http://purl.obolibrary.org/obo/BFO_0000051, range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+isPartOf,partOf (property URI - http://purl.obolibrary.org/obo/BFO_0000050; range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+hasPart,hasPart (property URI - http://purl.obolibrary.org/obo/BFO_0000051; range URI - http://purl.obolibrary.org/obo/ERO_0000071)
 position,
-description,abstract (property URI - http://purl.org/ontology/bibo/abstract, range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
-identifier,SWHID (property URI - http://vivoweb.org/ontology/core#swhid, range URI - http://www.w3.org/2001/XMLSchema#string)
-name,label (property URI - http://www.w3.org/2000/01/rdf-schema#label, range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
-sameAs,sameAs (property URI - http://www.w3.org/2002/07/owl#sameAs, range URI - http://purl.obolibrary.org/obo/ERO_0000071)
-url,has contact info.hasUrl (property URI - http://purl.obolibrary.org/obo/ARG_2000028, http://www.w3.org/2006/vcard/ns#hasURL, range URI - http://www.w3.org/2006/vcard/ns#Kind, http://www.w3.org/2006/vcard/ns#URL)
+description,abstract (property URI - http://purl.org/ontology/bibo/abstract; range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
+identifier,SWHID (property URI - http://vivoweb.org/ontology/core#swhid; range URI - http://www.w3.org/2001/XMLSchema#string)
+name,label (property URI - http://www.w3.org/2000/01/rdf-schema#label; range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
+sameAs,sameAs (property URI - http://www.w3.org/2002/07/owl#sameAs; range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+url,has contact info.hasUrl (property URI - http://purl.obolibrary.org/obo/ARG_2000028; http://www.w3.org/2006/vcard/ns#hasURL; range URI - http://www.w3.org/2006/vcard/ns#Kind; http://www.w3.org/2006/vcard/ns#URL)
 relatedLink,
 givenName,
 familyName,
 email,
 affiliation,
-identifier, relatedBy.relates.ORCID iD (property URI - http://vivoweb.org/ontology/core#relatedBy, http://vivoweb.org/ontology/core#relates, http://vivoweb.org/ontology/core#orcidId, range URI - http://vivoweb.org/ontology/core#Authorship, http://xmlns.com/foaf/0.1/Agent, http://www.w3.org/2001/XMLSchema#string)
-name, relatedBy.relates.label (property URI - http://vivoweb.org/ontology/core#relatedBy, http://vivoweb.org/ontology/core#relates, http://www.w3.org/2000/01/rdf-schema#label, range URI - http://vivoweb.org/ontology/core#Authorship, http://xmlns.com/foaf/0.1/Agent, http://www.w3.org/2000/01/rdf-schema#Literal)
+identifier, relatedBy.relates.ORCID iD (property URI - http://vivoweb.org/ontology/core#relatedBy; http://vivoweb.org/ontology/core#relates; http://vivoweb.org/ontology/core#orcidId; range URI - http://vivoweb.org/ontology/core#Authorship; http://xmlns.com/foaf/0.1/Agent; http://www.w3.org/2001/XMLSchema#string)
+name, relatedBy.relates.label (property URI - http://vivoweb.org/ontology/core#relatedBy; http://vivoweb.org/ontology/core#relates; http://www.w3.org/2000/01/rdf-schema#label; range URI - http://vivoweb.org/ontology/core#Authorship; http://xmlns.com/foaf/0.1/Agent; http://www.w3.org/2000/01/rdf-schema#Literal)
 address,
 reviewAspect,
 reviewBody,
@@ -66,7 +66,7 @@ continuousIntegration,
 buildInstructions,
 developmentStatus,
 embargoEndDate,
-funding, informationResourceSupportedBy.label (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy, http://www.w3.org/2000/01/rdf-schema#label, range URI - http://vivoweb.org/ontology/core#Grant, http://www.w3.org/2000/01/rdf-schema#Literal)
+funding, informationResourceSupportedBy.label (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy; http://www.w3.org/2000/01/rdf-schema#label; range URI - http://vivoweb.org/ontology/core#Grant; http://www.w3.org/2000/01/rdf-schema#Literal)
 issueTracker,
 referencePublication,
 readme,

--- a/crosswalks/VIVO.csv
+++ b/crosswalks/VIVO.csv
@@ -1,4 +1,4 @@
-Property,VIVO (ontology URI - https://github.com/vivo-ontologies/vivo-ontology/blob/master/vivo.owl; Software main class URI - http://purl.obolibrary.org/obo/ERO_0000071)
+Property,VIVO
 codeRepository,
 programmingLanguage,
 review,
@@ -16,44 +16,44 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,
-softwareVersion,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072; range URI - http://www.w3.org/2001/XMLSchema#string)
+softwareVersion,version
 storageRequirements,
 supportingData,
-author,relatedBy.relates (property URI - http://vivoweb.org/ontology/core#relatedBy; http://vivoweb.org/ontology/core#relates; range URI - http://vivoweb.org/ontology/core#Authorship; http://xmlns.com/foaf/0.1/Agent)
+author,relatedBy.relates
 citation,
 contributor,
 copyrightHolder,
 copyrightYear,
 dateCreated,
 dateModified,
-datePublished,date/time value (property URI - http://vivoweb.org/ontology/core#dateTimeValue; range URI - http://vivoweb.org/ontology/core#DateTimeValue)
+datePublished,date/time value
 editor,
 encoding,
 fileFormat,
-funder,informationResourceSupportedBy.assignedBy (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy; http://vivoweb.org/ontology/core#assignedBy; range URI - http://vivoweb.org/ontology/core#Grant; http://xmlns.com/foaf/0.1/Organization)
-keywords,freetextKeywords (property URI - http://vivoweb.org/ontology/core#freetextKeyword; range URI - http://www.w3.org/2001/XMLSchema#string)
+funder,informationResourceSupportedBy.assignedBy
+keywords,freetextKeywords
 license,
 producer,
 provider,
 publisher,
 sponsor,
-version,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072; range URI - http://www.w3.org/2001/XMLSchema#string)
+version,version
 isAccessibleForFree,
-isPartOf,partOf (property URI - http://purl.obolibrary.org/obo/BFO_0000050; range URI - http://purl.obolibrary.org/obo/ERO_0000071)
-hasPart,hasPart (property URI - http://purl.obolibrary.org/obo/BFO_0000051; range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+isPartOf,partOf
+hasPart,hasPart
 position,
-description,abstract (property URI - http://purl.org/ontology/bibo/abstract; range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
-identifier,SWHID (property URI - http://vivoweb.org/ontology/core#swhid; range URI - http://www.w3.org/2001/XMLSchema#string)
-name,label (property URI - http://www.w3.org/2000/01/rdf-schema#label; range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
-sameAs,sameAs (property URI - http://www.w3.org/2002/07/owl#sameAs; range URI - http://purl.obolibrary.org/obo/ERO_0000071)
-url,has contact info.hasUrl (property URI - http://purl.obolibrary.org/obo/ARG_2000028; http://www.w3.org/2006/vcard/ns#hasURL; range URI - http://www.w3.org/2006/vcard/ns#Kind; http://www.w3.org/2006/vcard/ns#URL)
+description,abstract
+identifier,SWHID
+name,label
+sameAs,sameAs
+url,has contact info.hasUrl
 relatedLink,
 givenName,
 familyName,
 email,
 affiliation,
-identifier, relatedBy.relates.ORCID iD (property URI - http://vivoweb.org/ontology/core#relatedBy; http://vivoweb.org/ontology/core#relates; http://vivoweb.org/ontology/core#orcidId; range URI - http://vivoweb.org/ontology/core#Authorship; http://xmlns.com/foaf/0.1/Agent; http://www.w3.org/2001/XMLSchema#string)
-name, relatedBy.relates.label (property URI - http://vivoweb.org/ontology/core#relatedBy; http://vivoweb.org/ontology/core#relates; http://www.w3.org/2000/01/rdf-schema#label; range URI - http://vivoweb.org/ontology/core#Authorship; http://xmlns.com/foaf/0.1/Agent; http://www.w3.org/2000/01/rdf-schema#Literal)
+identifier, relatedBy.relates.ORCID iD
+name, relatedBy.relates.label
 address,
 reviewAspect,
 reviewBody,
@@ -66,7 +66,7 @@ continuousIntegration,
 buildInstructions,
 developmentStatus,
 embargoEndDate,
-funding, informationResourceSupportedBy.label (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy; http://www.w3.org/2000/01/rdf-schema#label; range URI - http://vivoweb.org/ontology/core#Grant; http://www.w3.org/2000/01/rdf-schema#Literal)
+funding, informationResourceSupportedBy.label
 issueTracker,
 referencePublication,
 readme,

--- a/crosswalks/VIVO.csv
+++ b/crosswalks/VIVO.csv
@@ -1,0 +1,74 @@
+Property,VIVO (ontology URI - https://github.com/vivo-ontologies/vivo-ontology/blob/master/vivo.owl, Software main class URI - http://purl.obolibrary.org/obo/ERO_0000071)
+codeRepository,
+programmingLanguage,
+review,
+runtimePlatform,
+targetProduct,
+applicationCategory,
+applicationSubCategory,
+downloadUrl,
+fileSize,
+installUrl,
+memoryRequirements,
+operatingSystem,
+permissions,
+processorRequirements,
+releaseNotes,
+softwareHelp,
+softwareRequirements,
+softwareVersion,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072, range URI - http://www.w3.org/2001/XMLSchema#string)
+storageRequirements,
+supportingData,
+author,relatedBy.relates (property URI - http://vivoweb.org/ontology/core#relatedBy, http://vivoweb.org/ontology/core#relates, range URI - http://vivoweb.org/ontology/core#Authorship, http://xmlns.com/foaf/0.1/Agent)
+citation,
+contributor,
+copyrightHolder,
+copyrightYear,
+dateCreated,
+dateModified,
+datePublished,date/time value (property URI - http://vivoweb.org/ontology/core#dateTimeValue, range URI - http://vivoweb.org/ontology/core#DateTimeValue)
+editor,
+encoding,
+fileFormat,
+funder,informationResourceSupportedBy.assignedBy (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy, http://vivoweb.org/ontology/core#assignedBy, range URI - http://vivoweb.org/ontology/core#Grant, http://xmlns.com/foaf/0.1/Organization)
+keywords,freetextKeywords (property URI - http://vivoweb.org/ontology/core#freetextKeyword, range URI - http://www.w3.org/2001/XMLSchema#string)
+license,
+producer,
+provider,
+publisher,
+sponsor,
+version,version (property URI - http://purl.obolibrary.org/obo/ERO_0000072, range URI - http://www.w3.org/2001/XMLSchema#string)
+isAccessibleForFree,
+isPartOf,partOf (property URI - http://purl.obolibrary.org/obo/BFO_0000050, range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+hasPart,hasPart (property URI - http://purl.obolibrary.org/obo/BFO_0000051, range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+position,
+description,abstract (property URI - http://purl.org/ontology/bibo/abstract, range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
+identifier,SWHID (property URI - http://vivoweb.org/ontology/core#swhid, range URI - http://www.w3.org/2001/XMLSchema#string)
+name,label (property URI - http://www.w3.org/2000/01/rdf-schema#label, range URI - http://www.w3.org/2000/01/rdf-schema#Literal)
+sameAs,sameAs (property URI - http://www.w3.org/2002/07/owl#sameAs, range URI - http://purl.obolibrary.org/obo/ERO_0000071)
+url,has contact info.hasUrl (property URI - http://purl.obolibrary.org/obo/ARG_2000028, http://www.w3.org/2006/vcard/ns#hasURL, range URI - http://www.w3.org/2006/vcard/ns#Kind, http://www.w3.org/2006/vcard/ns#URL)
+relatedLink,
+givenName,
+familyName,
+email,
+affiliation,
+identifier, relatedBy.relates.ORCID iD (property URI - http://vivoweb.org/ontology/core#relatedBy, http://vivoweb.org/ontology/core#relates, http://vivoweb.org/ontology/core#orcidId, range URI - http://vivoweb.org/ontology/core#Authorship, http://xmlns.com/foaf/0.1/Agent, http://www.w3.org/2001/XMLSchema#string)
+name, relatedBy.relates.label (property URI - http://vivoweb.org/ontology/core#relatedBy, http://vivoweb.org/ontology/core#relates, http://www.w3.org/2000/01/rdf-schema#label, range URI - http://vivoweb.org/ontology/core#Authorship, http://xmlns.com/foaf/0.1/Agent, http://www.w3.org/2000/01/rdf-schema#Literal)
+address,
+reviewAspect,
+reviewBody,
+endDate,
+roleName,
+startDate,
+softwareSuggestions,
+maintainer,
+continuousIntegration,
+buildInstructions,
+developmentStatus,
+embargoEndDate,
+funding, informationResourceSupportedBy.label (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy, http://www.w3.org/2000/01/rdf-schema#label, range URI - http://vivoweb.org/ontology/core#Grant, http://www.w3.org/2000/01/rdf-schema#Literal)
+issueTracker,
+referencePublication,
+readme,
+hasSourceCode,
+isSourceCodeOf,


### PR DESCRIPTION
# What does this pull request do?
Adds crosswalk between codemeta and the VIVO ontology software class and its object and data properties.

# What's new?
The VIVO.csv file which is describing the crosswalk. The second column besides the name of object/data property, specify  object/data  property URIs and range. Moreover, if some mapping is more complex and include more elements from the graph dot is used as separator in the following syntax:

funder, informationResourceSupportedBy.assignedBy (property URI - http://vivoweb.org/ontology/core#informationResourceSupportedBy; http://vivoweb.org/ontology/core#assignedBy; range URI - http://vivoweb.org/ontology/core#Grant; http://xmlns.com/foaf/0.1/Organization)

This mean information about funder organization might be found starting from a Software class through its object properties http://vivoweb.org/ontology/core#informationResourceSupportedBy which is linking a Software with a Grant, and the next level is to use http://vivoweb.org/ontology/core#assignedBy object property of the linked Grant to get Funder (an instance of http://xmlns.com/foaf/0.1/Organization).

In order to make this crosswalk, an analysis of the VIVO ontology and its alignment (extension) with codemeta was done. More details about extensions of the VIVO ontology can be found [here](https://github.com/vivo-ontologies/vivo-ontology/pulls?q=is%3Apr+label%3A%22software+codemeta+alignment%22)  

# Additional Notes:
The crosswalk will be validated in the practice via implementation of [a REST API endpoints in VIVO]( https://github.com/ivanmrsulja/VIVO/commits/feature/rsmd/) which will work with codemeta json data (which are mapped and preserved in the VIVO graph)

The work is supported by a small FAIR-Impact grant.  