### PR TITLE
Remove non-consequential empty line in codemeta.jsonld

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -71,7 +71,6 @@
       "url": { "@id": "schema:url", "@type": "@id"},
       "version": { "@id": "schema:version"},
       "author": { "@id": "schema:author", "@container": "@list" },
-      
       "softwareSuggestions": { "@id": "codemeta:softwareSuggestions", "@type": "@id"},
       "continuousIntegration": { "@id": "codemeta:continuousIntegration", "@type": "@id"},
       "buildInstructions": { "@id": "codemeta:buildInstructions", "@type": "@id"},


### PR DESCRIPTION
it makes reader wonder if there is meaning to it, eg. some groupping of which I think none

It was introduced long ago in 34cb8d12a4b2d454856412c8adc60dd313c87fb0