### PR TITLE
Update CONTRIBUTORS.MD + remove email addresses

### DIFF
--- a/CONTRIBUTORS.MD
+++ b/CONTRIBUTORS.MD
@@ -105,7 +105,7 @@ operates according to the rules specified in the
 | Thomas Morrell | Caltech Library | [@tmorell](https://github.com/tmorrell) |
 | Valentin Lorentz | Software Heritage | [@progval](https://github.com/progval) |
 
-## Post-V3.0 contributors
+## V3.1 contributors
 
 | Name             | Institution             | GitHub  |
 |------------------|-------------------------| --------|


### PR DESCRIPTION
- Add names to Post-V3.0 contributors table
  - @tmorell from #398 #386
  - @slint from #396
  - @hmenager from #393
  - @esgg from #384
  - @hm-raws #378
  - @yarikoptic from #375
  - @Mazztok45 from #361
  - @chenejac from #366
- Put V3.0 names into a table just like other releases
- Update: Remove contributors' email addresses to avoid spam (see a comment below)