### PR TITLE
Remove invalid relatedSoftware property

### DIFF
--- a/crosswalks/swMATH.csv
+++ b/crosswalks/swMATH.csv
@@ -72,4 +72,3 @@ referencePublication,standard_articles
 readme,
 hasSourceCode,
 isSourceCodeOf,
-relatedSoftware,related_software


### PR DESCRIPTION
This property is not part of the CodeMeta schema and has been removed to maintain validity.