### PR TITLE
Add HydroShare model program crosswalk

### DIFF
--- a/crosswalks/hydroshare-modelprogram.csv
+++ b/crosswalks/hydroshare-modelprogram.csv
@@ -40,15 +40,15 @@ publisher,
 sponsor,
 version,ModelProgramMetadata.version
 isAccessibleForFree,
-isPartOf,ResourceMetadata.relations
-hasPart,ResourceMetadata.relations
+isPartOf,ResourceMetadata.relation
+hasPart,ResourceMetadata.relation
 position,
 description,
 identifier,
 name,ResourceMetadata.title
-sameAs,ResourceMetadata.relations
+sameAs,ResourceMetadata.relation
 url,ModelProgramMetadata.website / ModelProgramMetadata.url
-relatedLink,ResourceMetadata.relations
+relatedLink,ResourceMetadata.relation
 givenName,
 familyName,
 email,
@@ -69,7 +69,8 @@ developmentStatus,
 embargoEndDate,
 funding,ResourceMetadata.awards
 issueTracker,
-referencePublication,ResourceMetadata.relations
+referencePublication,ResourceMetadata.relation
 readme,
 hasSourceCode,
 isSourceCodeOf,
+


### PR DESCRIPTION
Adds a crosswalk converting metadata of [Model Program](https://help.hydroshare.org/hydroshare-resources/content-types/model-program/) research software objects in HydroShare to CodeMeta. The metadata properties are mapped from the [HydroShare model program metadata](https://github.com/hydroshare/hsclient/blob/master/docs/metadata/ModelProgramMetadata.md) (e.g., `codeRepository` or `programmingLanguage`) and the containing [HydroShare resource metadata](https://github.com/hydroshare/hsclient/blob/master/docs/metadata/ResourceMetadata.md) (e.g., `review` and `citation`).