### PR TITLE
Change Codemeta namespace from `https://codemeta.github.io/terms/` to `https://w3id.org/codemeta/terms/`

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -3,7 +3,7 @@
       "type": "@type",
       "id": "@id",
       "schema":"http://schema.org/",
-      "codemeta": "https://w3id.org/codemeta/terms",
+      "codemeta": "https://w3id.org/codemeta/terms/",
       "Organization": {"@id": "schema:Organization"},
       "Person": {"@id": "schema:Person"},
       "Review": {"@id": "schema:Review"},


### PR DESCRIPTION
This PR updates the context in the JSON-LD file so the context in CodeMeta is resolvable with a w3id. 

This was agreed on the Paris hackatchon (codeMeta Party) in fall, 2025.

Related Discussion: https://github.com/codemeta/codemeta/discussions/360

@progval 

PS: Sorry for the delay