### PR TITLE
adding `softwareVersion` to the zenodo crosswalk to be converted to `version`

### DIFF
--- a/crosswalks/Zenodo.csv
+++ b/crosswalks/Zenodo.csv
@@ -16,7 +16,7 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,
-softwareVersion,
+softwareVersion,version
 storageRequirements,
 supportingData,
 author,creators

--- a/crosswalks/Zenodo.csv
+++ b/crosswalks/Zenodo.csv
@@ -16,7 +16,7 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,
-softwareVersion,version,
+softwareVersion,version
 storageRequirements,
 supportingData,
 author,creators

--- a/crosswalks/Zenodo.csv
+++ b/crosswalks/Zenodo.csv
@@ -16,7 +16,7 @@ processorRequirements,
 releaseNotes,
 softwareHelp,
 softwareRequirements,
-softwareVersion,version
+softwareVersion,version,
 storageRequirements,
 supportingData,
 author,creators


### PR DESCRIPTION
I'd like to propose adding `softwareVersion` to the Zenodo crosswalk to be converted to `version`.