### PR TITLE
Stop the aggregate crosswalk table from silently dropping properties

### DIFF
--- a/crosswalks/MODS.csv
+++ b/crosswalks/MODS.csv
@@ -70,3 +70,5 @@ funding,
 issueTracker,"relatedItem/location/url[@displayName='Issue Tracker']"
 referencePublication,relatedItem[@type='isReferencedBy']
 readme,relatedItem[@type='constituent']
+hasSourceCode,
+isSourceCodeOf,

--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -20,6 +20,12 @@ written."""
 def check_property_names_match(filename, properties1, properties2):
     """Checks the list of properties in properties1 is the same as in
     properties2. Exits with a human-readable error if they don't."""
+    if len(properties1) != len(properties2):
+        print('Error in {}: expected {} properties, found {}. The aggregate '
+              'table can only be built if every crosswalk lists exactly the '
+              'properties in properties_description.csv, in the same order.'
+              .format(filename, len(properties1) - 1, len(properties2) - 1))
+        exit(1)
     for (prop1, prop2) in zip(properties1, properties2):
         if prop1 != prop2:
             print('Error in {}: property names {} and {} should be the same'
@@ -42,6 +48,11 @@ def read_terms(prop_desc, filename):
     # Read rows from a translation table in crosswalks.
     with open(SOURCE_DIR / filename) as fd:
         rows = list(csv.reader(fd))
+
+    # Some tables end with notes about terms of the other vocabulary that have
+    # no CodeMeta equivalent. They have an empty first cell, are not part of
+    # the crosswalk, and cannot be aggregated; skip them explicitly.
+    rows = [row for row in rows if row and row[0]]
 
     # Split the two rows of the translation table.
     (codemeta_names, crosswalk_names) = columns_from_rows(rows)


### PR DESCRIPTION
`crosswalk.csv` on master has 72 rows, but `properties_description.csv` defines 73 properties. `hasSourceCode` and `isSourceCodeOf` are missing from the aggregate table for all 45 crosswalks, not just for the one that caused it.

Cause: `check_property_names_match` compares the two property lists with `zip()`, which stops at the shorter one, so a crosswalk with missing rows passes the check. `rows_from_columns` then does `zip(*cols)` and truncates the whole table to the shortest column. `crosswalks/MODS.csv` is two rows short, so it quietly trims two rows off everything.

This is the same failure #345 fixed in the data ("currently it will produce only 70, omitting the last three properties"). It fixed the files but not the check, and MODS.csv landed on master later (#329), so it came back.

The change: compare the lengths before the element-wise comparison, and skip the trailing note rows with an empty property cell (ASCL's `,used in`, codemeta-V1's eight) explicitly instead of relying on `zip` to drop them. Plus the two missing rows in MODS.csv, left empty — MODS `relatedItem` has no type that fits a source-code link and I'd rather not invent one.

`python3 scripts/aggregate.py`, same tree, before and after: 72 rows -> 74, with the first 72 byte-identical, so nothing already in the table moves. Reverting either half puts it back: with MODS short the script now exits 1 instead of quietly emitting 72 rows; with only the MODS rows added and the check left alone, dropping one row from any other crosswalk truncates again in silence.

`crosswalk.csv` is deliberately not in this PR, per CONTRIBUTING.

Worth flagging: #486 adds 11 properties and touches no crosswalk. With this check in place its CI would fail until each crosswalk gets those 11 rows; without it, the 11 new properties would simply be absent from the published table. Happy to send that as a follow-up.

Disclosure: written with AI assistance (Claude).
