### PR TITLE
Use https for the schema.org namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ crosswalk table, website, software and other related content.
     - [Code as a research object: updates, prototypes, next steps](http://mozillascience.org/code-as-a-research-object-updates-prototypes-next-steps/)
     - [What else is needed for code reuse](http://mozillascience.org/what-else-is-needed-for-code-reuse/)
     - [JSON-LD for software discovery, reuse and credit](http://www.arfon.org/json-ld-for-software-discovery-reuse-and-credit)
-- [JSON-LD.org](http://json-ld.org/)
-- [Schema.org](http://schema.org/)
+- [JSON-LD.org](https://json-ld.org/)
+- [Schema.org](https://schema.org/)

--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -2,7 +2,7 @@
   "@context": {
       "type": "@type",
       "id": "@id",
-      "schema":"http://schema.org/",
+      "schema":"https://schema.org/",
       "codemeta": "https://w3id.org/codemeta/terms/",
       "Organization": {"@id": "schema:Organization"},
       "Person": {"@id": "schema:Person"},

--- a/examples/schema-org-codemeta.json
+++ b/examples/schema-org-codemeta.json
@@ -1,5 +1,15 @@
 {
-    "@context": ["http://schema.org", {"author": {"@id": "schema:author", "@container": "@list"} } ] ,
+    "@context": {
+        "@vocab": "https://schema.org/",
+        "schema": "https://schema.org/",
+        "author": {"@id": "schema:author", "@container": "@list"},
+        "codeRepository": {"@id": "schema:codeRepository", "@type": "@id"},
+        "dateCreated": {"@id": "schema:dateCreated", "@type": "schema:Date"},
+        "dateModified": {"@id": "schema:dateModified", "@type": "schema:Date"},
+        "datePublished": {"@id": "schema:datePublished", "@type": "schema:Date"},
+        "downloadUrl": {"@id": "schema:downloadUrl", "@type": "@id"},
+        "license": {"@id": "schema:license", "@type": "@id"}
+    },
     "name": "Generate CodeMeta Metadata for R Packages",
     "description": "Codemeta defines a 'JSON-LD' format for describing software metadata. This package provides utilities to generate, parse, and modify codemeta.jsonld files automatically for R packages.",
     "identifier": {"@id": "http://dx.doi.org/10.5281/zenodo.XXXX"},


### PR DESCRIPTION
The `schema` prefix of the CodeMeta context now points to `https://schema.org/` instead of `http://schema.org/`, per the official schema.org recommendation. Two links in the README are also updated.

Closes #373.

Split from #486 (work by @dgarijo and the CodeMeta v4 contributors).