### PR TITLE
Declare contributor as an ordered list

### DIFF
--- a/codemeta.jsonld
+++ b/codemeta.jsonld
@@ -18,7 +18,7 @@
       "applicationSubCategory": { "@id": "schema:applicationSubCategory", "@type": "@id"},
       "citation": { "@id": "schema:citation"},
       "codeRepository": { "@id": "schema:codeRepository", "@type": "@id"},
-      "contributor": { "@id": "schema:contributor"},
+      "contributor": { "@id": "schema:contributor", "@container": "@list" },
       "copyrightHolder": { "@id": "schema:copyrightHolder"},
       "copyrightYear": { "@id": "schema:copyrightYear"},
       "dateCreated": {"@id": "schema:dateCreated", "@type": "schema:Date" },


### PR DESCRIPTION
`contributor` gets `"@container": "@list"`, exactly like `author`. Declaring `contributor` as a list preserves the order given by the authors of a codemeta.json file.

This is a prerequisite for dropping `position` (which should be removed in a follow-up PR).

Split from #486 (work by @dgarijo and the CodeMeta v4 contributors).